### PR TITLE
feat(core): add theme override support for addon views

### DIFF
--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -53,7 +53,7 @@ class ViewServiceProvider extends ServiceProvider
 
                         $addonViewPath = $addonOverridesPath . '/' . $dir;
                         if (is_dir($addonViewPath) && str_contains($dir, '_')) {
-                            // This looks like an addon namespace (e.g., quote_manager)
+                            // This looks like an addon namespace
                             $this->app['view']->prependNamespace($dir, $addonViewPath);
                         }
                     }


### PR DESCRIPTION
Allow themes to override addon views by scanning theme directories for folders with underscore names (addon namespaces) and registering them with prependNamespace() to take priority over addon views.