### PR TITLE
feat(invoices): add extension point for invoice sidebar

### DIFF
--- a/resources/views/admin/core/invoices/show.blade.php
+++ b/resources/views/admin/core/invoices/show.blade.php
@@ -165,6 +165,7 @@
             </div>
             @endif
 
+            @stack('invoice-sidebar')
 
             @if ($invoice->isDraft() && staff_has_permission('admin.create_invoices'))
             <form method="POST" action="{{ route($routePath . '.validate', ['invoice' => $invoice]) }}">


### PR DESCRIPTION
Add @stack('invoice-sidebar') to allow addons to inject content into the invoice show page sidebar.