### PR TITLE
fix(theme): resolve cache key mismatch in locale-aware theme configuration

### DIFF
--- a/app/DTO/Core/Extensions/ThemeSectionDTO.php
+++ b/app/DTO/Core/Extensions/ThemeSectionDTO.php
@@ -67,14 +67,14 @@ class ThemeSectionDTO
         return $this->json['thumbnail'] ?? 'https://via.placeholder.com/1000x250';
     }
 
-    public function render(bool $cache = true): string
+    public function render(bool $useCache = true): string
     {
         $path = $this->json['path'];
         try {
-            if ($cache && app()->isProduction()) {
-                $cache = app('theme')->getSetting()['sections_html'] ?? collect();
-                if ($cache->has($path)) {
-                    return $cache->get($path);
+            if ($useCache && app()->isProduction()) {
+                $cachedHtml = app('theme')->getSetting()['sections_html'] ?? collect();
+                if ($cachedHtml->has($path)) {
+                    return $cachedHtml->get($path);
                 }
             }
             if (! view()->exists($path)) {

--- a/app/Theme/ThemeManager.php
+++ b/app/Theme/ThemeManager.php
@@ -95,13 +95,9 @@ class ThemeManager
     private static function getEnabledLocales(): array
     {
         try {
-            $locales = array_keys(\App\Services\Core\LocaleService::getLocalesNames());
-
-            return array_unique(array_map(function ($locale) {
-                return str_contains($locale, '_') ? explode('_', $locale)[0] : $locale;
-            }, $locales));
+            return array_keys(\App\Services\Core\LocaleService::getLocalesNames());
         } catch (\Exception $e) {
-            return ['fr', 'en'];
+            return ['fr', 'en', 'fr_FR', 'en_GB'];
         }
     }
 
@@ -260,9 +256,6 @@ class ThemeManager
                 'socials' => SocialNetwork::where('hidden', false)->orderBy('position')->get(),
                 'sections_pages' => $this->getSectionsPages(),
                 'sections' => Section::orderBy('order')->get(),
-                'sections_html' => Section::orderBy('order')->get()->mapWithKeys(function (Section $item) {
-                    return [$item->path => $item->toDTO()->render(false)];
-                }),
             ]);
         });
     }


### PR DESCRIPTION
## Summary

- `getEnabledLocales()` truncated locale codes (`fr_FR` -> `fr`) while `getSetting()` used the full locale from `app()->getLocale()` (`fr_FR`), causing `clearCache()` to never invalidate the actual cache keys (`theme_configuration_fr_FR`). Stale data persisted for up to 7 days.
- Removes pre-rendered `sections_html` from the theme cache to prevent silently failed Blade renders from being persisted.
- Fixes variable shadowing in `ThemeSectionDTO::render()` where `$cache` (bool param) was overwritten by a Collection.

## Test plan

- [x] Verified fix in production: sections render correctly in FR on first load with empty cache
- [x] Verified EN locale also works after cache clear
- [x] Verified `clearCache()` now targets the correct Redis keys (`theme_configuration_fr_FR`, `theme_configuration_en_GB`)
- [x] Laravel Pint passes on both modified files
- [x] No regression: sections still render dynamically via `renderIsolated()` when `sections_html` is absent from cache