### PR TITLE
fix(themes): re-include theme subfolders recursively + bootstrap typo

### DIFF
--- a/resources/themes/.gitignore
+++ b/resources/themes/.gitignore
@@ -1,3 +1,5 @@
-!default/*
-!boostrap/*
 *
+!default/
+!default/**
+!bootstrap/
+!bootstrap/**


### PR DESCRIPTION
## Bug / Context

Two latent bugs in `resources/themes/.gitignore` make it impossible to commit new files under any tracked theme directory, and silently exclude any theme named `bootstrap`.

```
!default/*
!boostrap/*
*
```

### Bug 1 — non-recursive rescue

`!default/*` only re-includes the **direct** children of `default/`. New files such as `default/views/foo.blade.php` are excluded by the catch-all `*` because `default/views/` (the parent) is already excluded, and per the gitignore spec:

> It is not possible to re-include a file if a parent directory of that file is excluded.
> (git help gitignore)

Existing files committed before this `.gitignore` landed are unaffected (gitignore does not apply to tracked files), which is why the bug went unnoticed.

### Bug 2 — typo

`!boostrap/*` was meant to be `bootstrap/*`. Spotted and acknowledged in commit `2aa2744` (`feat(auth): international phone input`) as a follow-up that never landed. Any theme dropped at `resources/themes/bootstrap/` is therefore silently excluded.

## Fix

```diff
-!default/*
-!boostrap/*
-*
+*
+!default/
+!default/**
+!bootstrap/
+!bootstrap/**
```

The two-step pattern `!dir/` + `!dir/**` is the documented way to keep a parent directory **and** all its descendants tracked once the catch-all is in play.

## Plan post-merge

- `master` has a similar bug (`!default` / `!boostrap` without trailing wildcard). It will be cured by the eventual `v2.16` -> `master` merge, or can be patched in a follow-up PR if the merge window is far out.