### PR TITLE
fix(build): keep symlinked theme and addon paths working on Vite 8

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,9 @@ import laravel from 'laravel-vite-plugin';
 import { glob } from "glob";
 
 export default defineConfig({
+    resolve: {
+        preserveSymlinks: true,
+    },
     plugins: [
         laravel({
             input: [


### PR DESCRIPTION
## Context

Since the Vite 6 -> 8 bump (5cc0985), `vite build` fails whenever themes or addons are
symlinked into the project instead of being real folders. That is the usual layout when
each extension lives in its own repository and is linked into `resources/themes/<uuid>`
and `addons/<uuid>`.

Vite 8 replaced the esbuild + Rollup pair with Rolldown as its single bundler. The new
resolver identifies a module by its **real** path rather than the symlinked one, so a
linked theme is re-anchored outside the project root and its relative imports of
`resources/global` stop resolving:

```
[UNRESOLVED_IMPORT] Could not resolve '../../../global/js/init.js'
  in ../Themes/<theme-repo>/resources/themes/wave/js/app.js
```

## Fix

One option in `vite.config.js`:

```js
resolve: {
    preserveSymlinks: true,
},
```

It tells Vite to determine file identity by the original path instead of the path after
following symlinks.

## Evidence

Real builds, same symlinked entry points, only the variable below changes:

| Vite | laravel-vite-plugin | `preserveSymlinks` | Result |
|---|---|---|---|
| 6.4.3 | 1.2.0 | no | `built in 14.49s` |
| 8.1.5 | 1.2.0 | no | `Build failed`, 8 unresolved imports |
| 8.1.5 | 3.1.3 | no | `Build failed`, 8 unresolved imports |
| 8.1.5 | 3.1.3 | **yes** | `built in 9.31s` |
| 8.2.2 | 3.2.0 | no | `Build failed`, 4 unresolved imports |
| 8.2.2 | 3.2.0 | **yes** | `built in 462ms` |

Row 2 isolates the cause: the old plugin under Vite 8 fails too, so this comes from the
Vite bump and not from `laravel-vite-plugin`. The last two rows cover the versions
proposed in #116 and #117, which are affected in the same way.

## Sources

- Vite 8 announcement, Rolldown as the single bundler: https://vite.dev/blog/announcing-vite8
- `resolve.preserveSymlinks` (default `false`): https://vite.dev/config/shared-options#resolve-preservesymlinks
- v7 -> v8 migration guide, resolver option mapping (`esbuildOptions.preserveSymlinks` ->
  `!rolldownOptions.resolve.symlinks`): https://vite.dev/guide/migration
- Vite 8.2.2 changelog, `respect resolve.preserveSymlinks when resolving root` (fix #23197):
  https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md

## Notes

- No-op on a standard checkout where extensions are real directories, so nothing changes
  for installs that do not use symlinks.
- The behaviour change is not documented in the migration guide; the table above is the
  only evidence I have for it.
- Verified with `vite build` only; I did not test the dev server.
