### PR TITLE
fix(npm): add a name to package.json so the lock file stops drifting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-    "name": "ClientXCMS",
+    "name": "clientxcms",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "name": "clientxcms",
             "dependencies": {
                 "@grafikart/drop-files-element": "^1.0.9",
                 "@preline/accordion": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "clientxcms",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## Context

`package.json` has no `name` field. When the field is missing, npm falls back to the name
of the current directory to fill `name` in `package-lock.json`. The lock therefore records
whatever the checkout folder happens to be called, and flips back and forth as soon as the
project is worked on from more than one place:

```diff
-    "name": "ClientXCMS",
+    "name": "laravel",
```

That is what a container mounting the project under `/workspaces/laravel` produces. Every
`npm install` then shows up as a spurious lock file change, unrelated to any dependency.

## Fix

Add an explicit name, which pins the value regardless of the folder:

```json
"name": "clientxcms",
```

Lowercase, per npm naming rules. The package stays `private: true`, so this is not about
publishing anything.

## Evidence

Copied `package.json` + `package-lock.json` into a directory named `laravel` and ran
`npm install --package-lock-only`:

| | `name` written to the lock |
|---|---|
| before the fix | `laravel` (follows the folder) |
| after the fix | `clientxcms` (stable) |

The lock diff is limited to the `name` field in the two places npm writes it. No dependency,
version or resolution changed.

## Notes

- Ran with `--package-lock-only --ignore-scripts`; no install side effects.
