### PR TITLE
fix(errors): branded error page turns every form validation error into a 500

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -71,7 +71,8 @@ class Handler extends ExceptionHandler
         if ($exception instanceof ViewException && \Str::contains($exception->getMessage(), 'Vite manifest not found at')) {
             return response("Vite manifest not found. Please execute 'npm install && npm run build'", 404);
         }
-        $status = $this->isHttpException($exception) ? $exception->getStatusCode() : 500;
+        $response = parent::render($request, $exception);
+        $status = $response->getStatusCode();
         $canRenderBrandedPage = in_array($status, self::RENDERED_STATUSES, true)
             && ! $request->expectsJson()
             && ($this->isHttpException($exception) || ! config('app.debug'));
@@ -96,7 +97,7 @@ class Handler extends ExceptionHandler
             }
         }
 
-        return parent::render($request, $exception);
+        return $response;
     }
 
     private function errorView($request, int $status, array $data): mixed

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,6 +20,29 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
+    private ?string $environmentFileSnapshot = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $contents = @file_get_contents($this->app->environmentFilePath());
+        $this->environmentFileSnapshot = $contents === false ? null : $contents;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->environmentFileSnapshot !== null) {
+            $path = $this->app->environmentFilePath();
+
+            if (@file_get_contents($path) !== $this->environmentFileSnapshot) {
+                file_put_contents($path, $this->environmentFileSnapshot);
+            }
+        }
+
+        parent::tearDown();
+    }
+
     protected function performAction(string $method, string $url, array $abbilities = ['*'], array $data = []): TestResponse
     {
         $this->seed(AdminSeeder::class);


### PR DESCRIPTION
## Bug

`Handler::render()` computes the status from the exception:

```php
$status = $this->isHttpException($exception) ? $exception->getStatusCode() : 500;
$canRenderBrandedPage = in_array($status, self::RENDERED_STATUSES, true)
    && ! $request->expectsJson()
    && ($this->isHttpException($exception) || ! config('app.debug'));
```

`ValidationException` and `AuthenticationException` are **not** `HttpException`, so `$status` falls back to `500`, which is in `RENDERED_STATUSES`. When `config('app.debug')` is false, the last condition is true as well, so the branded 500 page is returned **instead of** the redirect Laravel builds from those exceptions.

`APP_DEBUG=false` is the production value. So on a production install, every failed form submit returns a 500 page instead of coming back to the form with its error messages, and every unauthenticated request returns a 500 instead of the login redirect.

### How to reproduce

With a clean checkout (`APP_DEBUG=false` in `.env.testing`, as tracked):

```
php vendor/bin/phpunit --testsuite=Unit,Feature
```

20 tests fail with `Session is missing expected key [errors]` or `received 500`, across `AvatarTest`, `SecurityQuestionTest`, `SupportControllerTest`, `CheckoutTest`, `TrustedDevicesUiTest`, `ProfileControllerTest`, `ServiceControllerTest`, `CustomerBannedLoginTest`, `ServiceLiveStatusTest`.

CI is green today only by accident: `SettingsCoreControllerTest` posts `app_debug`, the controller calls `EnvEditor::updateEnv()`, and `App::environmentFilePath()` resolves to `.env.testing` while testing. So that test **rewrites the tracked `.env.testing`** with `APP_DEBUG=true` early in the run (alphabetical order puts `Feature/Admin/` first) and the later tests get the debug behaviour. It also leaves the repository dirty after any test run.

## Fix

Two commits:

1. `app/Exceptions/Handler.php` - build the response through `parent::render()` first and brand the page from the status that was actually rendered. Redirects (302) are no longer in `RENDERED_STATUSES`, so validation and auth failures keep Laravel's behaviour; 404/500/503 and friends are still branded exactly as before.
2. `tests/TestCase.php` - snapshot the environment file in `setUp()` and restore it in `tearDown()` when a test rewrote it, so the suite stops mutating a tracked file and stops depending on that mutation.

## Quality

- `php vendor/bin/phpunit --testsuite=Unit,Feature`: 1048 tests, 2594 assertions, 0 failures, 4 skipped (PHP 8.3.33, MySQL, `.env.testing` untouched after the run).
- `vendor/bin/pint --test app/Exceptions/Handler.php tests/TestCase.php`: PASS.
- Same run on plain `master` before the fix: green, but leaves `.env.testing` modified with 13 changed keys.