### PR TITLE
fix(tests): flaky SmsServiceTest comes from the customer factory drawing invalid phone numbers

### DIFF
--- a/database/factories/Core/CustomerFactory.php
+++ b/database/factories/Core/CustomerFactory.php
@@ -22,7 +22,7 @@ class CustomerFactory extends Factory
      */
     public function definition(): array
     {
-        $phone = '07'.random_int(10000000, 99999999);
+        $phone = '07'.random_int(3, 9).str_pad((string) random_int(0, 9999999), 7, '0', STR_PAD_LEFT);
 
         return [
             'firstname' => fake()->firstName(),


### PR DESCRIPTION
## Bug

`Tests\Unit\Services\Auth\SmsServiceTest::test_customer_sms_code_round_trip` fails intermittently on CI with `Failed asserting that false is true` at line 88. It is currently failing on #118, which touches `vite.config.js` only.

The cause is in `database/factories/Core/CustomerFactory.php`:

```php
$phone = '07'.random_int(10000000, 99999999);
```

That draws prefixes `071` through `079` uniformly. `070`, `071` and `072` are not assigned to French mobiles, so libphonenumber rejects them and `sendTwoFactorSmsCode()` returns `false`. Two prefixes out of nine means roughly one run in four fails.

Measured with the bundled libphonenumber (40 draws per prefix, `FR` region):

| Prefix | Invalid |
|---|---|
| 070, 071, 072 | 40/40 |
| 069 | 31/40 |
| 063 | 5/40 |
| others (06x, 073-079) | 0/40 |

## Fix

Draw `073` to `079`, which are all assigned:

```php
$phone = '07'.random_int(3, 9).str_pad((string) random_int(0, 9999999), 7, '0', STR_PAD_LEFT);
```

0 invalid numbers over 2000 draws with the same checker.

Tests that need an invalid number keep setting it explicitly (`test_non_e164_phone_is_rejected` writes `not-a-phone` straight to the column), so nothing loses coverage.

## Quality

- `SmsServiceTest` run 6 times in a row: 6/6 green (9 tests, 29 assertions each).
- `php vendor/bin/phpunit --testsuite=Unit,Feature`: 1048 tests, 2594 assertions, 0 failures, 4 skipped.
- `vendor/bin/pint --test database/factories/Core/CustomerFactory.php`: PASS.